### PR TITLE
Target 4.19 with v10.19

### DIFF
--- a/v10.19/Containerfile.catalog
+++ b/v10.19/Containerfile.catalog
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
The base image used specifies which OCP version's catalog the FBC fragment will be added to. As there is not yet a public 4.19 image, use brew.