### PR TITLE
release-4.17: release 60e64ee

### DIFF
--- a/v10.17/catalog-template.json
+++ b/v10.17/catalog-template.json
@@ -43,7 +43,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:06dcf7cfcebadcc7536e59ba4b8978e9862b3303486706adf0e502624fb379f7"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:17e4816ce48fe9e387503f3fece60dce901070c7923ed5e956dbb0080360b4a5"
         }
     ]
 }

--- a/v10.17/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.17/catalog/windows-machine-config-operator/catalog.json
@@ -130,7 +130,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.17.1",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:06dcf7cfcebadcc7536e59ba4b8978e9862b3303486706adf0e502624fb379f7",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:17e4816ce48fe9e387503f3fece60dce901070c7923ed5e956dbb0080360b4a5",
     "properties": [
         {
             "type": "olm.package",
@@ -147,7 +147,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-05-28T20:22:23Z",
+                    "createdAt": "2025-06-03T17:42:40Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -210,11 +210,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:beef4c03b2f8f026f69bfd5878d67b9ba58dfbc5c0b0a289acf5e930a465f3fe"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:ba892f84e923e83a32d5f66dd6f61ff5a6b51cdeba1ef3ae2b250d822b1b0482"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:06dcf7cfcebadcc7536e59ba4b8978e9862b3303486706adf0e502624fb379f7"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:17e4816ce48fe9e387503f3fece60dce901070c7923ed5e956dbb0080360b4a5"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.17 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/60e64ee8a3857c375051390cb01dbdf364553056

This commit was generated using hack/release_snapshot.sh