### PR TITLE
release-4.19: release e68ee5d

### DIFF
--- a/v10.19/catalog-template.json
+++ b/v10.19/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b5ce8c431510206f6f041ea394e357932115e4e9e6cd81ad45e992809ef7d572"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2"
         }
     ]
 }

--- a/v10.19/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.19/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.19.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b5ce8c431510206f6f041ea394e357932115e4e9e6cd81ad45e992809ef7d572",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-06-12T16:26:05Z",
+                    "createdAt": "2025-08-13T14:03:04Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:b311194d83470ba2fc2a7ba801bb45fca70a86683d2404f263c13217c3f14a78"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:8cebc62f65019d780baa9b907c455371c7aeb79f6e6b722a4048ba62e7cf86ee"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b5ce8c431510206f6f041ea394e357932115e4e9e6cd81ad45e992809ef7d572"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.19 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/e68ee5d54e7a7557272b09c4afdd4e47e81b845a

This commit was generated using hack/release_snapshot.sh