### PR TITLE
release-4.19: release c9afa91

### DIFF
--- a/v10.19/catalog-template.json
+++ b/v10.19/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ce638a1058e42e12bcb14dbff4ce3c1f469a5ddda8367db5ac6095470c48345d"
         }
     ]
 }

--- a/v10.19/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.19/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.19.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ce638a1058e42e12bcb14dbff4ce3c1f469a5ddda8367db5ac6095470c48345d",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-08-13T14:03:04Z",
+                    "createdAt": "2025-08-13T17:14:48Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:8cebc62f65019d780baa9b907c455371c7aeb79f6e6b722a4048ba62e7cf86ee"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:c47759b1e4ec297099197b4e5504b58e6fb89b53cc323b488bcd516f0be68c6f"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:78caa275563b6a4b0a57bb72d731583059b3db665d7be8b764e8505fa9940aa2"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ce638a1058e42e12bcb14dbff4ce3c1f469a5ddda8367db5ac6095470c48345d"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.19 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/c9afa914806cfa357e8f582dd11b2af7cd4e5cf0
Snapshot used: windows-machine-config-operator-release-4-19-dl4br

This commit was generated using hack/release_snapshot.sh