### PR TITLE
release-4.20: release 3e4bd45

### DIFF
--- a/v10.20/catalog-template.json
+++ b/v10.20/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:03856f047f0699b2252e8b04052fef3bcd432dac6ab405d73b9213b82fe031af"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:a291044f8bf5bb53206f6535d76f0597e91736193478aba5a52f08be840998bc"
         }
     ]
 }

--- a/v10.20/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.20/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.20.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:03856f047f0699b2252e8b04052fef3bcd432dac6ab405d73b9213b82fe031af",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:a291044f8bf5bb53206f6535d76f0597e91736193478aba5a52f08be840998bc",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-08-19T16:48:52Z",
+                    "createdAt": "2025-08-21T03:40:13Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:6f39eaf06f5c3e49c9d1026fed1a1942efe2dcd6c3d043fb0ca9c8f7c22a65a9"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:e1da23ff7c0601d225591a474cfc68e6fd8b6ee673c1e0bf91e53074190acf02"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:03856f047f0699b2252e8b04052fef3bcd432dac6ab405d73b9213b82fe031af"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:a291044f8bf5bb53206f6535d76f0597e91736193478aba5a52f08be840998bc"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.20 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/3e4bd45ad527b74d6c8ab74742e04c59a936c369

Snapshot used: windows-machine-config-operator-release-4-20-69v6r

This commit was generated using hack/release_snapshot.sh