### PR TITLE
release-4.20: release 42fc22c

### DIFF
--- a/v10.20/catalog-template.json
+++ b/v10.20/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b780a07575470f17661f3af7c44b4ccbaa0bb396ba51ced8b357936a113c2546"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:274f65e03318a97f9b8e0e61a2e830173d036806dfb085589d30a9394ef45307"
         }
     ]
 }

--- a/v10.20/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.20/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.20.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b780a07575470f17661f3af7c44b4ccbaa0bb396ba51ced8b357936a113c2546",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:274f65e03318a97f9b8e0e61a2e830173d036806dfb085589d30a9394ef45307",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-08-23T11:35:12Z",
+                    "createdAt": "2025-08-28T15:24:25Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:0a36d9acc66e78b4dff4a1feba22afbdb04a41acd1d58a88077346a5507f5e0d"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:e416096883c6ee63dd88faca178a3caf51a74e23bc54efca750ae438a7cf47ff"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:b780a07575470f17661f3af7c44b4ccbaa0bb396ba51ced8b357936a113c2546"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:274f65e03318a97f9b8e0e61a2e830173d036806dfb085589d30a9394ef45307"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.20 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/42fc22c649675289e90a5f2593f78ca7e5f399ac

Snapshot used: windows-machine-config-operator-release-4-20-6lfnb

This commit was generated using hack/release_snapshot.sh