### PR TITLE
release-4.18: Add 10.18.2 and  release 9c20667

### DIFF
--- a/v10.18/catalog-template.json
+++ b/v10.18/catalog-template.json
@@ -41,7 +41,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:eefeeede9a1b9f03684b0866b7695a6c696804c1bd6ec95985d52339195d65c1"
         }
     ]
 }

--- a/v10.18/catalog-template.json
+++ b/v10.18/catalog-template.json
@@ -20,6 +20,11 @@
                     "name": "windows-machine-config-operator.v10.18.1",
                     "replaces": "windows-machine-config-operator.v10.18.0",
                     "skipRange": ">=10.17.0 <10.18.1"
+                },
+                {
+                    "name": "windows-machine-config-operator.v10.18.2",
+                    "replaces": "windows-machine-config-operator.v10.18.1",
+                    "skipRange": ">=10.17.0 <10.18.2"
                 }
             ],
             "name": "stable",
@@ -29,6 +34,10 @@
         {
             "schema": "olm.bundle",
             "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4c365cdc291de517f581b12694460ddfe288ce51452d7877fb5e764d17418489"
+        },
+        {
+            "schema": "olm.bundle",
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
         },
         {
             "schema": "olm.bundle",

--- a/v10.18/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.18/catalog/windows-machine-config-operator/catalog.json
@@ -20,6 +20,11 @@
             "name": "windows-machine-config-operator.v10.18.1",
             "replaces": "windows-machine-config-operator.v10.18.0",
             "skipRange": ">=10.17.0 <10.18.1"
+        },
+        {
+            "name": "windows-machine-config-operator.v10.18.2",
+            "replaces": "windows-machine-config-operator.v10.18.1",
+            "skipRange": ">=10.17.0 <10.18.2"
         }
     ]
 }
@@ -149,6 +154,98 @@
                     "features.operators.openshift.io/token-auth-azure": "false",
                     "features.operators.openshift.io/token-auth-gcp": "false",
                     "olm.skipRange": ">=10.17.0 <10.18.1",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-windows-machine-config-operator",
+                    "operators.openshift.io/valid-subscription": "[\"Red Hat OpenShift support for Windows Containers\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.32.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v3",
+                    "repository": "https://github.com/openshift/windows-machine-config-operator",
+                    "support": "Red Hat"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {},
+                "description": "### Introduction\nThe Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to\nbe run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.18/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),\nor by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.18/windows_containers/byoh-windows-instance.html)\nThe operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.\n\nUsage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to\ndeploy Windows containers workloads in production clusters should acquire a subscription before attempting to\ninstall this operator. Users without a subscription can try the community operator, a distribution which lacks\nofficial support.\n\n### Pre-requisites\n* A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)\n* OCP 4.18 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking\n* [WMCO prerequisites](https://docs.openshift.com/container-platform/4.18/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)\n\n### Usage\nOnce the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing\nthe private key that will be used to access the Windows VMs:\n```\n# Create secret containing the private key in the openshift-windows-machine-config-operator namespace\noc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator\n```\nWe strongly recommend not using the same\n[private key](https://docs.openshift.com/container-platform/4.18/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)\nused when installing the cluster\n\nBelow is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.\nPlease note that the windows-user-data secret will be created by the WMCO lazily when it is configuring the first\nWindows Machine. After that, the windows-user-data will be available for the subsequent MachineSets to be consumed.\nIt might take around 10 minutes for the Windows VM to be configured so that it joins the cluster. Please note that\nthe MachineSet should have following labels:\n* `machine.openshift.io/os-id: Windows`\n* `machine.openshift.io/cluster-api-machine-role: worker`\n* `machine.openshift.io/cluster-api-machine-type: worker`\n\nThe following label must be added to the Machine spec within the MachineSet spec:\n* `node-role.kubernetes.io/worker: \"\"`\n\nNot having these labels will result in the Windows node not being marked as a worker.\n\n`<infrastructureID>` should be replaced with the output of:\n```\noc get -o jsonpath='{.status.infrastructureName}{\"\\n\"}' infrastructure cluster\n```\n\nThe following template variables need to be replaced as follows with values from your vSphere environment:\n* `<Windows_VM_template>`: template name\n* `<VM Network Name>`: network name\n* `<vCenter DataCenter Name>`: datacenter name\n* `<Path to VM Folder in vCenter>`: path where your OpenShift cluster is running\n* `<vCenter Datastore Name>`: datastore name\n* `<vCenter Server FQDN/IP>`: IP address or FQDN of the vCenter server\n\nPlease note that on vSphere, Windows Machine names cannot be more than 15 characters long. The MachineSet name therefore\ncannot be more than 9 characters long, due to the way Machine names are generated from it.\n```\napiVersion: machine.openshift.io/v1beta1\nkind: MachineSet\nmetadata:\n  labels:\n    machine.openshift.io/cluster-api-cluster: <infrastructureID>\n  name: winworker\n  namespace: openshift-machine-api\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      machine.openshift.io/cluster-api-cluster: <infrastructureID>\n      machine.openshift.io/cluster-api-machineset: winworker\n  template:\n    metadata:\n      labels:\n        machine.openshift.io/cluster-api-cluster: <infrastructureID>\n        machine.openshift.io/cluster-api-machine-role: worker\n        machine.openshift.io/cluster-api-machine-type: worker\n        machine.openshift.io/cluster-api-machineset: winworker\n        machine.openshift.io/os-id: Windows\n    spec:\n      metadata:\n        labels:\n          node-role.kubernetes.io/worker: \"\"\n      providerSpec:\n        value:\n          apiVersion: vsphereprovider.openshift.io/v1beta1\n          credentialsSecret:\n            name: vsphere-cloud-credentials\n            namespace: openshift-machine-api\n          diskGiB: 128\n          kind: VSphereMachineProviderSpec\n          memoryMiB: 16384\n          metadata:\n            creationTimestamp: null\n          network:\n            devices:\n            - networkName: \"<VM Network Name>\"\n          numCPUs: 4\n          numCoresPerSocket: 1\n          snapshot: \"\"\n          template: <Windows_VM_template\n          userDataSecret:\n            name: windows-user-data\n          workspace:\n            datacenter: <vCenter DataCenter Name>\n            datastore: <vCenter Datastore Name>\n            folder: <Path to VM Folder in vCenter> # e.g. /DC/vm/ocp45-2tdrm\n            server: <vCenter Server FQDN/IP>\n```\nExample MachineSet for other cloud providers:\n- [AWS](https://docs.openshift.com/container-platform/4.18/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)\n- [Azure](https://docs.openshift.com/container-platform/4.18/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)\n- [GCP](https://docs.openshift.com/container-platform/4.18/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)\n\n### Limitations\n#### DeploymentConfigs\nWindows Nodes do not support workloads created via DeploymentConfigs. Please use a normal Deployment, or other method to\ndeploy workloads.\n\n### Reporting issues\nSupport for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.\nPlease read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.18/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)\nbefore opening a support case.",
+                "displayName": "Windows Machine Config Operator",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "windows"
+                ],
+                "maintainers": [
+                    {
+                        "name": "Red Hat, Windows Container Support for OpenShift",
+                        "email": "team-winc@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.31.0",
+                "provider": {
+                    "name": "Red Hat"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:f391499545a2981a3c3492766bbaae6a72a82db07d88251e85fda5d672a108e0"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "windows-machine-config-operator.v10.18.2",
+    "package": "windows-machine-config-operator",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946",
+    "properties": [
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "windows-machine-config-operator",
+                "version": "10.18.2"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[]",
+                    "capabilities": "Seamless Upgrades",
+                    "categories": "OpenShift Optional",
+                    "certified": "false",
+                    "createdAt": "2025-05-14T20:50:15Z",
+                    "description": "An operator that enables Windows container workloads on OCP",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "true",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "true",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "olm.skipRange": ">=10.17.0 <10.18.2",
                     "operatorframework.io/cluster-monitoring": "true",
                     "operatorframework.io/suggested-namespace": "openshift-windows-machine-config-operator",
                     "operators.openshift.io/valid-subscription": "[\"Red Hat OpenShift support for Windows Containers\"]",

--- a/v10.18/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.18/catalog/windows-machine-config-operator/catalog.json
@@ -204,11 +204,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:f391499545a2981a3c3492766bbaae6a72a82db07d88251e85fda5d672a108e0"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:f391499545a2981a3c3492766bbaae6a72a82db07d88251e85fda5d672a108e0"
         }
     ]
 }
@@ -216,7 +216,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.18.2",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:eefeeede9a1b9f03684b0866b7695a6c696804c1bd6ec95985d52339195d65c1",
     "properties": [
         {
             "type": "olm.package",
@@ -233,7 +233,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-05-14T20:50:15Z",
+                    "createdAt": "2025-08-23T11:10:22Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -296,11 +296,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:f391499545a2981a3c3492766bbaae6a72a82db07d88251e85fda5d672a108e0"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:f02312e0495dfdb0db23df77d11e03ca8ada228e9bee269a04fe54db20b297a1"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:4ebf4ace7dcaf0a935b83314b2a514baffca704b2f36cec5cd61dcf13e459946"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:eefeeede9a1b9f03684b0866b7695a6c696804c1bd6ec95985d52339195d65c1"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.18 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/9c20667d83f73a2a825065914a4e608864bf6d69

Snapshot used: windows-machine-config-operator-release-4-18-h2phb

This commit was generated using hack/release_snapshot.sh



follow-up to 

- https://github.com/openshift/windows-machine-config-operator/pull/2969