### PR TITLE
release-4.19: release 36ebddc

### DIFF
--- a/v10.19/catalog-template.json
+++ b/v10.19/catalog-template.json
@@ -32,7 +32,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ebf36e5b2eece132f4d2897f1c032d4f3c9a0570e3c104d0006eb62973831875"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:41411e216204ae1c31b7f49871035125b74c202b5eb2d6fbd69a25be79cc88f1"
         }
     ]
 }

--- a/v10.19/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.19/catalog/windows-machine-config-operator/catalog.json
@@ -119,7 +119,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.19.1",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ebf36e5b2eece132f4d2897f1c032d4f3c9a0570e3c104d0006eb62973831875",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:41411e216204ae1c31b7f49871035125b74c202b5eb2d6fbd69a25be79cc88f1",
     "properties": [
         {
             "type": "olm.package",
@@ -136,7 +136,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-08-28T16:24:37Z",
+                    "createdAt": "2025-09-08T17:45:58Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -199,11 +199,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:044e91fd7ce8ec38ec30dbb9fbb0840e4afc4301cc2e1c635307266a051cdc61"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:5cf08fc54259322ced4cee92d3f8497014b953c43d404eeec3643156e5363288"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ebf36e5b2eece132f4d2897f1c032d4f3c9a0570e3c104d0006eb62973831875"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:41411e216204ae1c31b7f49871035125b74c202b5eb2d6fbd69a25be79cc88f1"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.19 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/36ebddc79ff36bf0c5d1b5b0be1118d52a788061

Snapshot used: windows-machine-config-operator-release-4-19-zqz69

This commit was generated using hack/release_snapshot.sh