### PR TITLE
release-4.21: release eb7c53d

### DIFF
--- a/v10.21/catalog-template.json
+++ b/v10.21/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:f8149188abda77f4af360fccf383778e6c8bb35db92326c26f056463be79d0be"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:88b17b74f0bd26493f2e26f9b5bb7c72527973bf04d44ba6efe23dd4733ad69c"
         }
     ]
 }

--- a/v10.21/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.21/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.21.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:f8149188abda77f4af360fccf383778e6c8bb35db92326c26f056463be79d0be",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:88b17b74f0bd26493f2e26f9b5bb7c72527973bf04d44ba6efe23dd4733ad69c",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2025-10-09T04:31:04Z",
+                    "createdAt": "2025-10-09T22:03:58Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:6b9423ec9678ab4868448fad8ada473ee20e3a522c100368fe3d29bbc0023e8c"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:e8a5a874245d4f45868a12704903c9d005d1352a220988e05a5b1480bfd13664"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:f8149188abda77f4af360fccf383778e6c8bb35db92326c26f056463be79d0be"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:88b17b74f0bd26493f2e26f9b5bb7c72527973bf04d44ba6efe23dd4733ad69c"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.21 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/eb7c53d25d0d3333feecbfad9f343e27a504a49e

Snapshot used: windows-machine-config-operator-release-4-21-tzhng

This commit was generated using hack/release_snapshot.sh