### PR TITLE
release-4.22: release f4f9dfa

### DIFF
--- a/v10.22/catalog-template.json
+++ b/v10.22/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:71bec2a145ade76495fc772ad27a03eb0adaea379173e29ad0d1338978ced9d9"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:90687a4a7614c3dc7fbea6f3406bde2243eec3a63de2b489a184573ec5019397"
         }
     ]
 }

--- a/v10.22/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.22/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.22.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:71bec2a145ade76495fc772ad27a03eb0adaea379173e29ad0d1338978ced9d9",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:90687a4a7614c3dc7fbea6f3406bde2243eec3a63de2b489a184573ec5019397",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-01-29T06:20:10Z",
+                    "createdAt": "2026-02-18T14:57:40Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:80d4cdfe6a3cfe65f406fee50d422ad0b6db93a73b155e0f0f303f3eaad3d0a6"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:fa5113a38752baa876fabc763114bcbdcda309f8e5788c5acddee9942f1b1b0f"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:71bec2a145ade76495fc772ad27a03eb0adaea379173e29ad0d1338978ced9d9"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:90687a4a7614c3dc7fbea6f3406bde2243eec3a63de2b489a184573ec5019397"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.22 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/f4f9dfa5289fdc91fd98a8b9d12e9561ec7d6f02

Snapshot used: windows-machine-config-operator-release-4-2-20260218-144259-000

This commit was generated using hack/release_snapshot.sh