### PR TITLE
release-4.18: release d414362

### DIFF
--- a/v10.18/catalog-template.json
+++ b/v10.18/catalog-template.json
@@ -41,7 +41,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:136d449adf8a15d78fe1bc8a5df42208422fabebf48c0de56b44d14f07fd16da"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9e137448456bb5455767cba5ec3d7b4032a0124597e8d6cd32a4ee5a0febbb30"
         }
     ]
 }

--- a/v10.18/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.18/catalog/windows-machine-config-operator/catalog.json
@@ -216,7 +216,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.18.2",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:136d449adf8a15d78fe1bc8a5df42208422fabebf48c0de56b44d14f07fd16da",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9e137448456bb5455767cba5ec3d7b4032a0124597e8d6cd32a4ee5a0febbb30",
     "properties": [
         {
             "type": "olm.package",
@@ -233,7 +233,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-01-20T17:38:34Z",
+                    "createdAt": "2026-03-03T23:21:21Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -296,11 +296,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:0b1241f5b8e31f8ce707b6a8a08bbb6b91656cf65039bf3e09c84ad0e26bcdab"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:a2c51432db1dffab6f0c6d1794d4f334a221e8e1cd7157a4282d83b2e4eb0659"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:136d449adf8a15d78fe1bc8a5df42208422fabebf48c0de56b44d14f07fd16da"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9e137448456bb5455767cba5ec3d7b4032a0124597e8d6cd32a4ee5a0febbb30"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.18 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/d41436268321232b8e212a808b171fd02e960fb0

Snapshot used: windows-machine-config-operator-release-4-1-20260303-231123-000

This commit was generated using hack/release_snapshot.sh