### PR TITLE
release-4.22: release 95096b8

### DIFF
--- a/v10.22/catalog-template.json
+++ b/v10.22/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:5414ba9a621b882e5a2574852d417e14918d17bbf23f930e3c799af6cf6093f1"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:7272de393ec3eb826efefc9c14b7b873cd189fc488ccd11e9c32914a9a67815c"
         }
     ]
 }

--- a/v10.22/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.22/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.22.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:5414ba9a621b882e5a2574852d417e14918d17bbf23f930e3c799af6cf6093f1",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:7272de393ec3eb826efefc9c14b7b873cd189fc488ccd11e9c32914a9a67815c",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-03-04T15:16:37Z",
+                    "createdAt": "2026-03-07T09:46:43Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:c528265a66480b99fc7276d91f1e58e0c8832515e348072afb6493868cc39547"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:db6659d6ea7e4e6e8ae71223da59bfbf6ce53650a58fba151c205f3c3185d6f0"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:5414ba9a621b882e5a2574852d417e14918d17bbf23f930e3c799af6cf6093f1"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:7272de393ec3eb826efefc9c14b7b873cd189fc488ccd11e9c32914a9a67815c"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.22 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/95096b84d1380354b44da8d5cdea804d3c6df2ba

Snapshot used: windows-machine-config-operator-release-4-2-20260307-093626-000

This commit was generated using hack/release_snapshot.sh