### PR TITLE
release-4.22: release 44bd910

### DIFF
--- a/v10.22/catalog-template.json
+++ b/v10.22/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:de8fed9162f0813046bf538d8ce666647ddc0dbe8e36913183624f2540b6c66b"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1"
         }
     ]
 }

--- a/v10.22/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.22/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.22.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:de8fed9162f0813046bf538d8ce666647ddc0dbe8e36913183624f2540b6c66b",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-04-10T15:40:54Z",
+                    "createdAt": "2026-04-17T15:49:50Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:6b7d8f5bf398a59b86f6057927ac648f1a55f8d6e4fa33d49cbd13d6d31dd670"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:7a8447f083bb08a994145f002a4749fe64f9d76ba55ae7404748a9285dbe4220"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:de8fed9162f0813046bf538d8ce666647ddc0dbe8e36913183624f2540b6c66b"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.22 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/44bd910174bcb4564951ed57de9a2197d26614e1

Snapshot used: windows-machine-config-operator-release-4-2-20260417-154011-000

This commit was generated using hack/release_snapshot.sh