### PR TITLE
release-4.22: release 98f15bd

### DIFF
--- a/v10.22/catalog-template.json
+++ b/v10.22/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:1f492631806a5acdf7317ba3486b026bbd40cd5a3dd75557280a8712d2310a24"
         }
     ]
 }

--- a/v10.22/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.22/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.22.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:1f492631806a5acdf7317ba3486b026bbd40cd5a3dd75557280a8712d2310a24",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-04-17T15:49:50Z",
+                    "createdAt": "2026-04-22T14:49:27Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:7a8447f083bb08a994145f002a4749fe64f9d76ba55ae7404748a9285dbe4220"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:43a84a7a9bd10fbcd73d7146673f579dd67728bfdea3788b89a568eb429d1fa3"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:daf70c73704f2b25d89c052386cd783d77904c3b946917bbe5d420176e9ffee1"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:1f492631806a5acdf7317ba3486b026bbd40cd5a3dd75557280a8712d2310a24"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.22 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/98f15bdfae8c2de7d62c3ed273d7679d1ccce905

Snapshot used: windows-machine-config-operator-release-4-2-20260422-143825-000

This commit was generated using hack/release_snapshot.sh