### PR TITLE
release-5.0: set migrate level to none

### DIFF
--- a/hack/release-snapshot.sh
+++ b/hack/release-snapshot.sh
@@ -142,8 +142,8 @@ echo "Updated olm.bundle image hash in ${CATALOG_TEMPLATE_PATH}/catalog-template
 
 # default migrate level to none
 MIGRATE_LEVEL="none"
-if [[ "${TARGET_BRANCH}" == "master"  || "${TARGET_BRANCH}" > "release-4.16" ]]; then
-  # Adjust migrate level for OCP 4.17 and later
+if [[ "${TARGET_BRANCH}" < "release-5.0" && "${TARGET_BRANCH}" > "release-4.16" ]]; then
+  # Adjust migrate level for OCP 4.17 and later up to 5.0
   # See https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository
   MIGRATE_LEVEL="bundle-object-to-csv-metadata"
 fi


### PR DESCRIPTION
This pull request updates the logic for setting the `MIGRATE_LEVEL` variable in the `hack/release-snapshot.sh` script. The change refines the branch comparison to ensure that the migration level is only adjusted for OpenShift versions 4.17 up to, but not including, 5.0.

