### PR TITLE
Revert "release-5.0: set migrate level to none"

### DIFF
--- a/hack/release-snapshot.sh
+++ b/hack/release-snapshot.sh
@@ -142,8 +142,8 @@ echo "Updated olm.bundle image hash in ${CATALOG_TEMPLATE_PATH}/catalog-template
 
 # default migrate level to none
 MIGRATE_LEVEL="none"
-if [[ "${TARGET_BRANCH}" < "release-5.0" && "${TARGET_BRANCH}" > "release-4.16" ]]; then
-  # Adjust migrate level for OCP 4.17 and later up to 5.0
+if [[ "${TARGET_BRANCH}" == "master"  || "${TARGET_BRANCH}" > "release-4.16" ]]; then
+  # Adjust migrate level for OCP 4.17 and later
   # See https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository
   MIGRATE_LEVEL="bundle-object-to-csv-metadata"
 fi


### PR DESCRIPTION
Reverts openshift/windows-machine-config-operator-fbc#216

as per [slack conv](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1778873293588879?thread_ts=1778521722.379529&cid=C04PZ7H0VA8)