### PR TITLE
Update build-image-index , fbc-target-index-pruning-check and prefetch-dependencies-oci-ta  digests for 4.x release pipelines

### DIFF
--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
@@ -254,7 +254,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-pull-request.yaml
@@ -182,7 +182,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
@@ -179,7 +179,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-17-push.yaml
@@ -251,7 +251,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
@@ -254,7 +254,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-pull-request.yaml
@@ -182,7 +182,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
@@ -179,7 +179,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-18-push.yaml
@@ -251,7 +251,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
@@ -183,7 +183,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
@@ -255,7 +255,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-pull-request.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
@@ -180,7 +180,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
@@ -252,7 +252,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-19-push.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
@@ -183,7 +183,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
@@ -255,7 +255,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-pull-request.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
@@ -180,7 +180,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
@@ -252,7 +252,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-20-push.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
@@ -183,7 +183,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
@@ -255,7 +255,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-pull-request.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
@@ -180,7 +180,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
@@ -252,7 +252,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-21-push.yaml
@@ -337,7 +337,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
@@ -190,7 +190,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
@@ -266,7 +266,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-pull-request.yaml
@@ -348,7 +348,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
@@ -187,7 +187,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:b2874a995ea90137068d1ea406f90fff027053979aee9a036a42b404eca61ce7
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
@@ -263,7 +263,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:550afde50349e22ec11191ea0db9a49395ab46fef4e8317d820b6e946677ebeb
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
+++ b/.tekton/windows-machine-config-operator-fbc-release-4-22-push.yaml
@@ -348,7 +348,7 @@ spec:
         - name: name
           value: fbc-target-index-pruning-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:fcc6f1b21c12625ba5e157556bf7bafd03486cb265fe5e761cf352afb5d1adf1
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:0fb7feb722250a0f77e5d9d7b4e2536ec85ff4fc41d78378bbb84304cb7959be
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
This pull request updates Tekton pipeline task bundle references across multiple YAML files for various release and push/pull-request workflows. The main purpose is to point to newer versions (by digest) of the `prefetch-dependencies-oci-ta`, `build-image-index`, and `fbc-target-index-pruning-check` tasks.
