### PR TITLE
release-5.0: release f58c2b0

### DIFF
--- a/v11.0/catalog-template.json
+++ b/v11.0/catalog-template.json
@@ -23,7 +23,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:96e36a39d745be56b9896a28068a04146e4f0e1f60c620f57f7a25fc1a4cc682"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:e661b4fc89f0541ef7d7c769abf8dd2e780ee95d9964feae9dcc30551d71c1f4"
         }
     ]
 }

--- a/v11.0/catalog/windows-machine-config-operator/catalog.json
+++ b/v11.0/catalog/windows-machine-config-operator/catalog.json
@@ -22,7 +22,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v11.0.0",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:96e36a39d745be56b9896a28068a04146e4f0e1f60c620f57f7a25fc1a4cc682",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:e661b4fc89f0541ef7d7c769abf8dd2e780ee95d9964feae9dcc30551d71c1f4",
     "properties": [
         {
             "type": "olm.package",
@@ -39,7 +39,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-06-17T22:41:34Z",
+                    "createdAt": "2026-06-25T01:05:43Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -102,11 +102,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:3e732d41db6af666237488f44e2b377d731537935472abf3a248fe2043d3eba2"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:5c3a26009b0d47916c0cd22265d2aa29041b2ffa07411c4a292e880c0aa73cac"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:96e36a39d745be56b9896a28068a04146e4f0e1f60c620f57f7a25fc1a4cc682"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:e661b4fc89f0541ef7d7c769abf8dd2e780ee95d9964feae9dcc30551d71c1f4"
         }
     ]
 }


### PR DESCRIPTION
Updates v11.0 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/f58c2b0e30f021611449941fdd61834969997ea3

Snapshot used: windows-machine-config-operator-release-5-0-20260625-005516-000

This commit was generated using hack/release_snapshot.sh