### PR TITLE
release-4.21: release 4c87df4

### DIFF
--- a/v10.21/catalog-template.json
+++ b/v10.21/catalog-template.json
@@ -41,7 +41,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:2a74720d1cca8e5708288f7e71a56cbe686e297427d8e65a7abc2dbc52603b8a"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:bacab3236c469cdf112b903a6ac3a502a2e082103098efb27ea73766c68afe35"
         }
     ]
 }

--- a/v10.21/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.21/catalog/windows-machine-config-operator/catalog.json
@@ -216,7 +216,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.21.2",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:2a74720d1cca8e5708288f7e71a56cbe686e297427d8e65a7abc2dbc52603b8a",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:bacab3236c469cdf112b903a6ac3a502a2e082103098efb27ea73766c68afe35",
     "properties": [
         {
             "type": "olm.package",
@@ -233,7 +233,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-03-18T18:07:51Z",
+                    "createdAt": "2026-07-07T16:34:56Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -296,11 +296,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:cafd2ff164651b399f7d1a6b72f2f2d3a463e1240f4416b37d2d20a75df19e4b"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:246f18db2fd1d9b04ba6b82c5552677e00ed989535be59cea1f1a2f9f2e31be1"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:2a74720d1cca8e5708288f7e71a56cbe686e297427d8e65a7abc2dbc52603b8a"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:bacab3236c469cdf112b903a6ac3a502a2e082103098efb27ea73766c68afe35"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.21 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/4c87df407f2faf3cb9b261ef6b082a080d2f0098

Snapshot used: windows-machine-config-operator-release-4-2-20260707-162314-000

This commit was generated using hack/release_snapshot.sh