### PR TITLE
release-4.20: release 293c728 and  set stage registry for 10.20.2

### DIFF
--- a/v10.20/catalog-template.json
+++ b/v10.20/catalog-template.json
@@ -41,7 +41,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9dae119f791bda3848256bce31f2e6418eac7d8598d726e3430cf423cc2f1e16"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9dae119f791bda3848256bce31f2e6418eac7d8598d726e3430cf423cc2f1e16"
         }
     ]
 }

--- a/v10.20/catalog-template.json
+++ b/v10.20/catalog-template.json
@@ -41,7 +41,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9dae119f791bda3848256bce31f2e6418eac7d8598d726e3430cf423cc2f1e16"
+            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ff1f6aec183e744b17197aa343d542c99d1555c68f209a987ce2f32ccdb07408"
         }
     ]
 }

--- a/v10.20/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.20/catalog/windows-machine-config-operator/catalog.json
@@ -216,7 +216,7 @@
     "schema": "olm.bundle",
     "name": "windows-machine-config-operator.v10.20.2",
     "package": "windows-machine-config-operator",
-    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9dae119f791bda3848256bce31f2e6418eac7d8598d726e3430cf423cc2f1e16",
+    "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ff1f6aec183e744b17197aa343d542c99d1555c68f209a987ce2f32ccdb07408",
     "properties": [
         {
             "type": "olm.package",
@@ -233,7 +233,7 @@
                     "capabilities": "Seamless Upgrades",
                     "categories": "OpenShift Optional",
                     "certified": "false",
-                    "createdAt": "2026-03-30T17:05:08Z",
+                    "createdAt": "2026-07-11T11:58:34Z",
                     "description": "An operator that enables Windows container workloads on OCP",
                     "features.operators.openshift.io/cnf": "false",
                     "features.operators.openshift.io/cni": "true",
@@ -296,11 +296,11 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:acf8680eb2b86232b0418ecc73660ab838eaab12c517fd4fa0b3b4ceaffb765b"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:d1d4e54e004150b1275ec4eb2154353639874fe5da5c39e982982bb0548aa95c"
         },
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:9dae119f791bda3848256bce31f2e6418eac7d8598d726e3430cf423cc2f1e16"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:ff1f6aec183e744b17197aa343d542c99d1555c68f209a987ce2f32ccdb07408"
         }
     ]
 }


### PR DESCRIPTION
Updates v10.20 olm.bundle image to https://github.com/openshift/windows-machine-config-operator/commit/293c728dfb5e65571d26203d6832037b6a150320

Snapshot used: windows-machine-config-operator-release-4-2-20260711-114819-000

This commit was generated using hack/release_snapshot.sh