### PR TITLE
[release-4.19] Adds 10.19.3, updates references, and clean up outdated related images

### DIFF
--- a/v10.19/catalog-template.json
+++ b/v10.19/catalog-template.json
@@ -25,6 +25,11 @@
                     "name": "windows-machine-config-operator.v10.19.2",
                     "replaces": "windows-machine-config-operator.v10.19.1",
                     "skipRange": ">=10.18.0 <10.19.2"
+                },
+                {
+                    "name": "windows-machine-config-operator.v10.19.3",
+                    "replaces": "windows-machine-config-operator.v10.19.2",
+                    "skipRange": ">=10.18.0 <10.19.3"
                 }
             ],
             "name": "stable",

--- a/v10.19/catalog-template.json
+++ b/v10.19/catalog-template.json
@@ -46,7 +46,7 @@
         },
         {
             "schema": "olm.bundle",
-            "image": "registry.stage.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:6fae16a77d2f053bd77f69a9684356949e6e0c6f4ad88d86904e85782d03a286"
+            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:6fae16a77d2f053bd77f69a9684356949e6e0c6f4ad88d86904e85782d03a286"
         },
         {
             "schema": "olm.bundle",

--- a/v10.19/catalog/windows-machine-config-operator/catalog.json
+++ b/v10.19/catalog/windows-machine-config-operator/catalog.json
@@ -393,14 +393,6 @@
     "relatedImages": [
         {
             "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:28b265f57feeffde9410f45e217519cfefd8357f3de32c1634cae7c5166e1c71"
-        },
-        {
-            "name": "",
-            "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-operator-bundle@sha256:6fae16a77d2f053bd77f69a9684356949e6e0c6f4ad88d86904e85782d03a286"
-        },
-        {
-            "name": "",
             "image": "registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:483d5d28098f2263e3f531812c489ec167bc20ebd73acc7d9481304898897082"
         },
         {


### PR DESCRIPTION
This pull request updates the Windows Machine Config Operator catalog for version 10.19, adding a new operator version, updating image references, and cleaning up outdated related images.

follow-up to
- https://github.com/openshift/windows-machine-config-operator-fbc/pull/210

**Operator version updates:**

* Added a new operator version, `windows-machine-config-operator.v10.19.3`, to the `stable` channel in `catalog-template.json`, with appropriate `replaces` and `skipRange` fields.

**Image reference updates:**

* Changed the bundle image reference in `catalog-template.json` from the staging registry to the production registry for consistency and reliability.

**Related images cleanup:**

* Removed outdated `relatedImages` entries for older operator and bundle images from `catalog.json` to ensure only current images are referenced.